### PR TITLE
roll back tortoise, simplify installation, etc

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ generative audio tools for ComfyUI. highly experimental&mdash;expect things to b
     - save audio, convert audio
 
 ## installation
-```bash
-# make sure you have activated the python environment used by ComfyUI
+```shell
+# TORCH_CUDA_INDEX_URL=https://download.pytorch.org/whl/cu118  # for cuda 11.8
+TORCH_CUDA_INDEX_URL=https://download.pytorch.org/whl/cu121  # for cuda 12.1
+
 cd ComfyUI/custom_nodes
 git clone https://github.com/eigenpunk/ComfyUI-audio
 cd ComfyUI-audio
-# pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu118  # for cuda 11.8
-pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu121  # for cuda 12.1
-pip install -U audiocraft --no-deps
+pip install -r requirements.txt --extra-index-url $TORCH_CUDA_INDEX_URL
 ```
 
 ## would be nice to have maybe

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ generative audio tools for ComfyUI. highly experimental&mdash;expect things to b
     - audiocraft and transformers implementations
     - supports audio continuation, unconditional generation
 - [tortoise text-to-speech](https://github.com/neonbjb/tortoise-tts)
-    - uses [152334h's fork](https://github.com/152334H/tortoise-tts-fast)
 - [vall-e x text-to-speech](https://github.com/Plachtaa/VALL-E-X)
     - uses [korakoe's fork](https://github.com/korakoe/VALL-E-X)
 - [voicefixer2](https://github.com/voicefixer/voicefixer)
@@ -20,8 +19,8 @@ generative audio tools for ComfyUI. highly experimental&mdash;expect things to b
 cd ComfyUI/custom_nodes
 git clone https://github.com/eigenpunk/ComfyUI-audio
 cd ComfyUI-audio
-# pip install -r requirements.txt --index-url https://download.pytorch.org/whl/cu118  # for cuda 11.8
-pip install -r requirements.txt --index-url https://download.pytorch.org/whl/cu121  # for cuda 12.1
+# pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu118  # for cuda 11.8
+pip install -r requirements.txt --extra-index-url https://download.pytorch.org/whl/cu121  # for cuda 12.1
 pip install -U audiocraft --no-deps
 ```
 

--- a/__init__.py
+++ b/__init__.py
@@ -12,14 +12,26 @@ from .musicgen_hf_nodes import (
     NODE_CLASS_MAPPINGS as MGHF_NODE_CLASS_MAPPINGS,
     NODE_DISPLAY_NAME_MAPPINGS as MGHF_NODE_DISPLAY_NAME_MAPPINGS,
 )
-from .tortoise_nodes import (
-    NODE_CLASS_MAPPINGS as TORTOISE_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as TORTOISE_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .valle_x_nodes import (
-    NODE_CLASS_MAPPINGS as VEX_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as VEX_NODE_DISPLAY_MAPPINGS,
-)
+
+try:
+    from .tortoise_nodes import (
+        NODE_CLASS_MAPPINGS as TORTOISE_NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS as TORTOISE_NODE_DISPLAY_NAME_MAPPINGS,
+    )
+except Exception as e:
+    print(f"WARNING: ComfyUI-audio failed to import tortoise; reason: {e}")
+    TORTOISE_NODE_CLASS_MAPPINGS = {}
+    TORTOISE_NODE_DISPLAY_NAME_MAPPINGS = {}
+
+try:
+    from .valle_x_nodes import (
+        NODE_CLASS_MAPPINGS as VEX_NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS as VEX_NODE_DISPLAY_MAPPINGS,
+    )
+except Exception as e:
+    print(f"WARNING: ComfyUI-audio failed to import vall_e_x; reason: {e}")
+    VEX_NODE_CLASS_MAPPINGS = {}
+    VEX_NODE_DISPLAY_MAPPINGS = {}
 
 
 NODE_CLASS_MAPPINGS = {

--- a/__init__.py
+++ b/__init__.py
@@ -4,14 +4,29 @@ from .util_nodes import (
     NODE_CLASS_MAPPINGS as UTIL_NODE_CLASS_MAPPINGS,
     NODE_DISPLAY_NAME_MAPPINGS as UTIL_NODE_DISPLAY_NAME_MAPPINGS,
 )
-from .musicgen_nodes import (
-    NODE_CLASS_MAPPINGS as MGAC_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as MGAC_NODE_DISPLAY_NAME_MAPPINGS,
-)
-from .musicgen_hf_nodes import (
-    NODE_CLASS_MAPPINGS as MGHF_NODE_CLASS_MAPPINGS,
-    NODE_DISPLAY_NAME_MAPPINGS as MGHF_NODE_DISPLAY_NAME_MAPPINGS,
-)
+
+
+try:
+    from .musicgen_nodes import (
+        NODE_CLASS_MAPPINGS as MGAC_NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS as MGAC_NODE_DISPLAY_NAME_MAPPINGS,
+    )
+except Exception as e:
+    print(f"WARNING: ComfyUI-audio failed to import musicgen nodes; reason: {e}")
+    MGAC_NODE_CLASS_MAPPINGS = {}
+    MGAC_NODE_DISPLAY_NAME_MAPPINGS = {}
+
+
+try:
+    from .musicgen_hf_nodes import (
+        NODE_CLASS_MAPPINGS as MGHF_NODE_CLASS_MAPPINGS,
+        NODE_DISPLAY_NAME_MAPPINGS as MGHF_NODE_DISPLAY_NAME_MAPPINGS,
+    )
+except Exception as e:
+    print(f"WARNING: ComfyUI-audio failed to import musicgen_hf nodes; reason: {e}")
+    MGHF_NODE_CLASS_MAPPINGS = {}
+    MGHF_NODE_DISPLAY_NAME_MAPPINGS = {}
+
 
 try:
     from .tortoise_nodes import (
@@ -19,9 +34,10 @@ try:
         NODE_DISPLAY_NAME_MAPPINGS as TORTOISE_NODE_DISPLAY_NAME_MAPPINGS,
     )
 except Exception as e:
-    print(f"WARNING: ComfyUI-audio failed to import tortoise; reason: {e}")
+    print(f"WARNING: ComfyUI-audio failed to import tortoise nodes; reason: {e}")
     TORTOISE_NODE_CLASS_MAPPINGS = {}
     TORTOISE_NODE_DISPLAY_NAME_MAPPINGS = {}
+
 
 try:
     from .valle_x_nodes import (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,46 +1,5 @@
--e git+https://github.com/152334H/tortoise-tts-fast#egg=TorToiSe
-
-# vall-e x
-soundfile
-# torchvision
-tokenizers
-langid
-wget
-unidecode
-pyopenjtalk-prebuilt
-pypinyin
-inflect
-cn2an
-jieba
-eng_to_ipa
-openai-whisper
-matplotlib
-nltk
-lhotse
-sudachipy
-sudachidict_core
-vocos
-
-# audiocraft
-av
-einops
-flashy>=0.0.1
-hydra-core>=1.1
-hydra_colorlog
-julius
-num2words
-numpy
-sentencepiece
-spacy>=3.5.2
-huggingface_hub
-tqdm
-transformers>=4.31.0  # need Encodec there.
-demucs
-librosa
-torchmetrics
-encodec
-protobuf
-
+git+https://git@github.com/facebookresearch/audiocraft#egg=audiocraft
+git+https://github.com/korakoe/VALL-E-X#egg=vall_e_x
+git+https://github.com/neonbjb/tortoise-tts
 voicefixer2
-
-xformers
+deepspeed

--- a/tortoise_nodes.py
+++ b/tortoise_nodes.py
@@ -2,6 +2,7 @@ import os
 
 import torch
 from tortoise.api import TextToSpeech, pick_best_batch_size_for_gpu
+from tortoise.api_fast import TextToSpeech as FastTextToSpeech
 from tortoise.utils.audio import get_voices, load_voice
 
 from .util import do_cleanup, get_device, models_dir, object_to, obj_on_device
@@ -28,7 +29,9 @@ class TortoiseTTSLoader:
         return {
             "required": {
                 "kv_cache": ("BOOLEAN", {"default": True}),
-                "high_vram": ("BOOLEAN", {"default": False}),
+                "half": ("BOOLEAN", {"default": False}),
+                "use_deepspeed": ("BOOLEAN", {"default": False}),
+                "use_fast_api": ("BOOLEAN", {"default": False}),
             }
         }
 
@@ -37,7 +40,7 @@ class TortoiseTTSLoader:
     FUNCTION = "load"
     CATEGORY = "audio"
 
-    def load(self, kv_cache=False, high_vram=False, use_fast_api=False):
+    def load(self, kv_cache=True, half=False, use_deepspeed=False, use_fast_api=False):
         if self.model is not None:
             self.model = object_to(self.model, empty_cuda_cache=False)
             del self.model
@@ -45,7 +48,18 @@ class TortoiseTTSLoader:
             print("TortoiseTTSLoader: unloaded model")
 
         print("TortoiseTTSLoader: loading model")
-        self.model = TextToSpeech(models_dir=MODELS_PATH, high_vram=high_vram, kv_cache=kv_cache)
+        if use_fast_api:
+            print(
+                "TortoiseTTSLoader: using fast api; please note that diffusion, CLVP, and CVVP controls will "
+                "not be used, num_autoregressive_samples is fixed to 50, and max_mel_tokens will be ignored."
+            )
+        ctor = FastTextToSpeech if use_fast_api else TextToSpeech
+        self.model = ctor(
+            models_dir=MODELS_PATH,
+            half=half,
+            kv_cache=kv_cache,
+            use_deepspeed=use_deepspeed,
+        )
 
         return self.model, 24000
 
@@ -63,20 +77,18 @@ class TortoiseTTSGenerate:
                 "voice": (["random", *list(VOICES.keys())],),
                 "text": ("STRING", {"default": "hello world", "multiline": True}),
                 "batch_size": ("INT", {"default": 1, "min": 1}),
-                "latent_averaging_mode": (["tortoise", "global_windowed", "global"],),
-                "num_autoregressive_samples": ("INT", {"default": 80, "min": 0, "max": 10000, "step": 1}),
+                "num_autoregressive_samples": ("INT", {"default": 20, "min": 0, "max": 10000, "step": 1}),
                 "autoregressive_batch_size": ("INT", {"default": 0, "min": 0, "max": 1024, "step": 1}),
-                "temperature": ("FLOAT", {"default": 1.0, "min": 0.001, "step": 0.001}),
+                "temperature": ("FLOAT", {"default": 0.8, "min": 0.001, "step": 0.001}),
                 "length_penalty": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.001}),
-                "repetition_penalty": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.001}),
-                "top_p": ("FLOAT", {"default": 0.001, "min": 0.001, "max": 1.0, "step": 0.001}),
+                "repetition_penalty": ("FLOAT", {"default": 2.0, "min": 0.0, "max": 10.0, "step": 0.001}),
+                "top_p": ("FLOAT", {"default": 0.8, "min": 0.001, "max": 1.0, "step": 0.001}),
                 "max_mel_tokens": ("INT", {"default": 500, "min": 1, "max": 600, "step": 1}),
                 "cvvp_amount": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001}),
-                "diffusion_steps": ("INT", {"default": 100, "min": 0, "max": 4000}),
+                "diffusion_steps": ("INT", {"default": 20, "min": 0, "max": 4000}),
                 "cond_free": ("BOOLEAN", {"default": True}),
                 "cond_free_k": ("FLOAT", {"default": 2.0, "min": 0.0, "step": 0.01}),
                 "diffusion_temperature": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.001}),
-                "sampler": (["p", "ddim", "dpm++2m"],),
                 "seed": ("INT", {"default": 0, "min": 0}),
             },
         }
@@ -94,7 +106,6 @@ class TortoiseTTSGenerate:
         text: str = "",
         voice: str = "random",
         batch_size: int = 1,
-        latent_averaging_mode: str = "tortoise",
         num_autoregressive_samples: int = 80,
         autoregressive_batch_size: int = 0,
         temperature: float = 1.0,
@@ -107,21 +118,22 @@ class TortoiseTTSGenerate:
         cond_free: bool = False,
         cond_free_k: float = 0.0,
         diffusion_temperature: float = 1.0,
-        sampler: str = "p",
         seed: int = 0,
     ):
         device = get_device()
-        latent_averaging_mode = {
-            "tortoise": 0,
-            "global_windowed": 1,
-            "global": 2,
-        }[latent_averaging_mode]
         voice_samples, voice_latents = load_voice(voice, extra_voice_dirs=[VOICES_PATH])
 
         if autoregressive_batch_size == 0:
             autoregressive_batch_size = pick_best_batch_size_for_gpu()
 
         model.autoregressive_batch_size = autoregressive_batch_size
+
+        diffusion_kwargs = {
+            "diffusion_iterations": diffusion_steps,
+            "cond_free": cond_free,
+            "cond_free_k": cond_free_k,
+            "diffusion_temperature": diffusion_temperature,
+        } if not isinstance(model, FastTextToSpeech) else {}
 
         with (
             torch.random.fork_rng(),
@@ -136,7 +148,6 @@ class TortoiseTTSGenerate:
                 conditioning_latents=voice_latents,
                 k=batch_size,
                 verbose=True,
-                latent_averaging_mode=latent_averaging_mode,
                 num_autoregressive_samples=num_autoregressive_samples,
                 temperature=temperature,
                 length_penalty=length_penalty,
@@ -144,12 +155,8 @@ class TortoiseTTSGenerate:
                 top_p=top_p,
                 max_mel_tokens=max_mel_tokens,
                 cvvp_amount=cvvp_amount,
-                diffusion_iterations=diffusion_steps,
-                cond_free=cond_free,
-                cond_free_k=cond_free_k,
-                diffusion_temperature=diffusion_temperature,
-                sampler=sampler,
                 use_deterministic_seed=seed,
+                **diffusion_kwargs,
             )
             if batch_size > 1:
                 audio_out = [x.squeeze(0).cpu() for x in audio_out]


### PR DESCRIPTION
ditched tortoise-tts-fast, dependency situation too frustrating to be worth it
reverted back to neonbjb's tortoise implementation
simplified requirements.txt, installation should be less terrible now
import guards for each node implementation file so one failing import doesn't prevent other nodes from attempting to load